### PR TITLE
compare expiration time to seconds, not milliseconds

### DIFF
--- a/wallet/src/de/schildbach/wallet/ui/InputParser.java
+++ b/wallet/src/de/schildbach/wallet/ui/InputParser.java
@@ -309,7 +309,7 @@ public abstract class InputParser
 		final Protos.PaymentDetails paymentDetails = Protos.PaymentDetails.newBuilder().mergeFrom(paymentRequest.getSerializedPaymentDetails())
 				.build();
 
-		if (paymentDetails.hasExpires() && System.currentTimeMillis() >= paymentDetails.getExpires())
+		if (paymentDetails.hasExpires() && (System.currentTimeMillis() / 1000) >= paymentDetails.getExpires())
 			throw new PaymentRequestException.Expired("payment details expired: " + paymentDetails.getExpires());
 
 		if (!paymentDetails.getNetwork().equals(Constants.NETWORK_PARAMETERS.getPaymentProtocolId()))


### PR DESCRIPTION
BIP 70 specifies that the expiration date is in seconds, not milliseconds, but
Bitcoin Wallet is comparing the expiration date to currentTimeMillis(), which
leads to marking invoices as expired when in fact they are not yet expired.
This is resolved by dividing the milliseconds by 1000 to get seconds.
