### PR TITLE
Translate `dismiss` into `fermer`

### DIFF
--- a/wallet/res/values-fr/strings.xml
+++ b/wallet/res/values-fr/strings.xml
@@ -208,7 +208,7 @@
 
 	<!-- generic buttons -->
 	<string name="button_ok">OK</string>
-	<string name="button_dismiss">Refuser</string>
+	<string name="button_dismiss">Fermer</string>
 	<string name="button_cancel">Annuler</string>
 	<string name="button_retry">Ressayer</string>
 	<string name="button_help">Aide</string>


### PR DESCRIPTION
`Refuser` (which means `refuse`, `reject` or `decline`) doesn't make sense at all in this context.

For instance when you open the safety notes, the only action that you can do is to `refuse` it. `Fermer` (`close`) is more appropriate. I can't think of any better translation for now.
