### PR TITLE
don't add Android application record (AAR) in the NDEF push message

### DIFF
--- a/wallet/src/de/schildbach/wallet/util/Nfc.java
+++ b/wallet/src/de/schildbach/wallet/util/Nfc.java
@@ -47,7 +47,7 @@ public class Nfc
 			return false;
 
 		final NdefRecord uriRecord = wellKnownUriRecord(uri);
-		adapter.enableForegroundNdefPush(activity, ndefMessage(uriRecord, true, activity.getPackageName()));
+		adapter.enableForegroundNdefPush(activity, ndefMessage(uriRecord, false, activity.getPackageName()));
 
 		return true;
 	}


### PR DESCRIPTION
This allows the system to show a chooser dialog if multiple applications can handle "bitcoin:" uris.

**Note for other readers:** This only takes effect when doing a NDEF push (aka "Android Beam") at the main screen of the Bitcoin Wallet. If you perform a Android beam in the "request payment" screen the wallet will send a Payment Request (and thus the receiving application also needs to support payment requests).

![chooser_dialog_send_bitcoins](https://cloud.githubusercontent.com/assets/285900/2955280/519106ba-da7e-11e3-9b27-8791b9566348.png)
