### PR TITLE
update android-maven-plugin to version 3.8.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,7 @@
 				<plugin>
 					<groupId>com.jayway.maven.plugins.android.generation2</groupId>
 					<artifactId>android-maven-plugin</artifactId>
-					<version>3.7.0</version>
+					<version>3.8.0</version>
 					<configuration>
 						<genDirectory>${basedir}/gen</genDirectory>
 					</configuration>


### PR DESCRIPTION
I had the following error, that was solved by updating android-maven-plugin to 3.8.0.

[ERROR] Failed to execute goal com.jayway.maven.plugins.android.generation2:android-maven-plugin:3.7.0:generate-sources (default-generate-sources) on project wallet: Execution default-generate-sources of goal com.jayway.maven.plugins.android.generation2:android-maven-plugin:3.7.0:generate-sources failed: A required class was missing while executing com.jayway.maven.plugins.android.generation2:android-maven-plugin:3.7.0:generate-sources: Lorg/sonatype/aether/RepositorySystem;
