### PR TITLE
[InputParser] Import compressed WIF's

### DIFF
--- a/wallet/src/de/schildbach/wallet/ui/InputParser.java
+++ b/wallet/src/de/schildbach/wallet/ui/InputParser.java
@@ -150,6 +150,21 @@ public abstract class InputParser
 					error(R.string.input_parser_invalid_address);
 				}
 			}
+			else if (PATTERN_PRIVATE_KEY_COMPRESSED.matcher(input).matches())
+			{
+				try
+				{
+					final ECKey key = new DumpedPrivateKey(Constants.NETWORK_PARAMETERS, input).getKey();
+
+					handlePrivateKey(key);
+				}
+				catch (final AddressFormatException x)
+				{
+					log.info("got invalid address", x);
+
+					error(R.string.input_parser_invalid_address);
+				}
+			}
 			else if (PATTERN_TRANSACTION.matcher(input).matches())
 			{
 				try
@@ -370,5 +385,6 @@ public abstract class InputParser
 	private static final Pattern PATTERN_PRIVATE_KEY = Pattern
 			.compile((Constants.NETWORK_PARAMETERS.getId().equals(NetworkParameters.ID_MAINNET) ? "5" : "9") + "[" + new String(Base58.ALPHABET)
 					+ "]{50}");
+	private static final Pattern PATTERN_PRIVATE_KEY_COMPRESSED = Pattern.compile("[" + new String(Base58.ALPHABET)+ "]{50}");
 	private static final Pattern PATTERN_TRANSACTION = Pattern.compile("[0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ$\\*\\+\\-\\.\\/\\:]{100,}");
 }


### PR DESCRIPTION
Bitcoinj core currently supports importing compressed
WIFs: btac.es/1uxNKIN

The current parser simply checks if the WIF starts with a
5, which is incorrect. It should check if it starts with
a K or an L, then verify the length.

This commit is untested (unable to compile due to some maven issues)
but should be a basis of all that needs to change to properly
import compressed WIF's into bitcoinj
