### PR TITLE
no crash when backup sdcard not available

### DIFF
--- a/wallet/src/de/schildbach/wallet/ui/WalletActivity.java
+++ b/wallet/src/de/schildbach/wallet/ui/WalletActivity.java
@@ -991,7 +991,7 @@ public final class WalletActivity extends AbstractWalletActivity
 			{
 				cipherOut.close();
 			}
-			catch (final IOException x)
+			catch (final Exception x)
 			{
 				// swallow
 			}


### PR DESCRIPTION
fixes #138

When sdcard is mounted on PC then it is not available to bitcoin wallet.

Opening the output stream throws an IOException which is caught and presented to the user in a dialog https://github.com/schildbach/bitcoin-wallet/blob/003d28d973b972ed713e67ee2f170902df6793a7/wallet/src/de/schildbach/wallet/ui/WalletActivity.java#L960

But closing the outputstream still crashes since the output writer is null and the resulting NPE is not caught.  https://github.com/schildbach/bitcoin-wallet/blob/003d28d973b972ed713e67ee2f170902df6793a7/wallet/src/de/schildbach/wallet/ui/WalletActivity.java#L960
