### PR TITLE
Add 'bit' precision display

### DIFF
--- a/wallet/res/values/values.xml
+++ b/wallet/res/values/values.xml
@@ -12,6 +12,7 @@
 		<item>4</item>
 		<item>2/3</item>
 		<item>0/6</item>
+		<item>2/6</item>
 	</string-array>
 	<string-array name="preferences_precision_labels">
 		<item>BTC, 8 digits</item>
@@ -19,6 +20,7 @@
 		<item>BTC, 4 digits</item>
 		<item>mBTC, 2 digits</item>
 		<item>µBTC, no digits</item>
+		<item>bit, 2 digits</item>
 	</string-array>
 
 </resources>


### PR DESCRIPTION
WIth the rising popularity of bits as a denomination, I propose adding bit with two digits after the decimal point. This is very useful, because the former "µBTC, no digits", this does not result in a loss of information - the user sees his balance down to the last satoshi.

I didn't remove "µBTC, no digits" here because some people may like it, but honestly I would prefer to use bits.