### PR TITLE
Fix determination if transaction is still timelocked.

### DIFF
--- a/wallet/src/de/schildbach/wallet/ui/TransactionsListAdapter.java
+++ b/wallet/src/de/schildbach/wallet/ui/TransactionsListAdapter.java
@@ -369,7 +369,7 @@ public class TransactionsListAdapter extends BaseAdapter
 		if (rowExtendMessage != null)
 		{
 			final TextView rowMessage = (TextView) row.findViewById(R.id.transaction_row_message);
-			final boolean isTimeLocked = tx.isTimeLocked();
+			final boolean isTimeLocked = tx.isTimeLocked() && !tx.isFinal(wallet.getLastBlockSeenHeight() + 1, wallet.getLastBlockSeenTimeSecs());
 			rowExtendMessage.setVisibility(View.GONE);
 
 			if (isInternal)


### PR DESCRIPTION
Bitcoin Core merged @petertodd 's patch that will create timelocked payments by default (wallet only). These transactions currently show up as "untrusted" in Bitcoin Wallet.

This PR also looks at if a tx is final. If it is, it's just as good as a tx that is not timelocked at all (ignoring re-org edge cases).
