### PR TITLE
wallet-tool needs additional pkgs

### DIFF
--- a/wallet/README.recover.md
+++ b/wallet/README.recover.md
@@ -35,8 +35,7 @@ requiring your Ubuntu user password.
 
 On your PC, install the following Ubuntu packages:
 
-    sudo apt install android-tools-adb openssl git maven
-
+    sudo apt install android-tools-adb openssl git maven openjdk-9-jdk-headless openjdk-9-jre-headless
 On your Android device, go to Settings > Developer options and enable "USB debugging". On most
 recent devices you need to go to Settings > About first and tap on "Build number" multiple times
 until you see the "You are now a developer" message.


### PR DESCRIPTION
these instructions fail on Ubuntu 16.04 without openjdk packages for maven compilation
( openjdk-9-jdk-headless and openjdk-9-jre-headless)