### PR TITLE
Update link to Twitter account.

### DIFF
--- a/wallet/res/xml/preference_about.xml
+++ b/wallet/res/xml/preference_about.xml
@@ -49,7 +49,7 @@
         android:title="Twitter" >
         <intent
             android:action="android.intent.action.VIEW"
-            android:data="https://twitter.com/#!/bitcoin_wallet" />
+            android:data="https://twitter.com/bitcoin_wallet" />
     </Preference>
 
     <PreferenceCategory android:title="@string/about_category_credits" >


### PR DESCRIPTION
Twitter redirects users using the link https://twitter.com/#!/bitcoin_wallet
usually to https://twitter.com/bitcoin_wallet. However, in some cases like
on my smartphone I'm automatically redirected to the mobile link
https://mobile.twitter.com/#!/bitcoin_wallet which displays the
twitter startpage instead of the account. The reason seems to be located in
the question if someone is actively logged in or not.
The link https://twitter.com/bitcoin_wallet
works in all of my tested use cases.