### PR TITLE
Adds an option for private key in the address book

### DIFF
--- a/wallet/res/menu/wallet_addresses_context.xml
+++ b/wallet/res/menu/wallet_addresses_context.xml
@@ -22,5 +22,9 @@
         android:id="@+id/wallet_addresses_context_browse"
         android:showAsAction="never"
         android:title="@string/action_browse"/>
+    <item
+        android:id="@+id/wallet_addresses_private_key"
+        android:showAsAction="never"
+        android:title="@string/action_private_key"/>
 
 </menu>

--- a/wallet/res/values/strings.xml
+++ b/wallet/res/values/strings.xml
@@ -339,6 +339,7 @@
     <string name="button_settings">Settings</string>
     <string name="action_show_qr">Show QR code</string>
     <string name="action_browse">Browse</string>
+    <string name="action_private_key">Private key</string>
 
     <!-- generic strings -->
     <string name="time_today">today</string>

--- a/wallet/res/values/strings.xml
+++ b/wallet/res/values/strings.xml
@@ -340,6 +340,8 @@
     <string name="action_show_qr">Show QR code</string>
     <string name="action_browse">Browse</string>
     <string name="action_private_key">Private key</string>
+    <string name="dialog_private_key_title">Private key</string>
+    <string name="dialog_private_key_warning">Never, ever share your private key!</string>
 
     <!-- generic strings -->
     <string name="time_today">today</string>

--- a/wallet/src/de/schildbach/wallet/ui/WalletAddressesFragment.java
+++ b/wallet/src/de/schildbach/wallet/ui/WalletAddressesFragment.java
@@ -42,10 +42,12 @@ import de.schildbach.wallet.util.WholeStringBuilder;
 import de.schildbach.wallet_test.R;
 
 import android.app.Activity;
+import android.app.AlertDialog;
 import android.content.ClipData;
 import android.content.ClipboardManager;
 import android.content.ContentResolver;
 import android.content.Context;
+import android.content.DialogInterface;
 import android.content.Intent;
 import android.database.ContentObserver;
 import android.net.Uri;
@@ -186,6 +188,27 @@ public final class WalletAddressesFragment extends FancyListFragment {
                             Uri.withAppendedPath(blockExplorerUri, "address/" + address)));
 
                     mode.finish();
+                    return true;
+
+                case R.id.wallet_addresses_private_key:
+                    // Not in clipboard for security reasons, unless on testnet.
+                    final String privKey = getKey(position).getPrivateKeyAsWiF(Constants.NETWORK_PARAMETERS);
+                    if (Constants.TEST) {
+                        clipboardManager.setPrimaryClip(ClipData.newPlainText("Bitcoin privKey", privKey));
+                        log.info("private key copied to clipboard: {}", privKey);
+                    }
+                    final DialogBuilder builder = DialogBuilder.warn(activity, R.string.action_private_key);
+                    builder.setMessage(privKey);
+                    builder.singleDismissButton(new DialogInterface.OnClickListener() {
+                        @Override
+                        public void onClick(DialogInterface dialogInterface, int i) {
+                            mode.finish();
+                        }
+                    });
+                    final AlertDialog dialog = builder.create();
+                    dialog.setCanceledOnTouchOutside(false);
+                    dialog.show();
+
                     return true;
                 }
 

--- a/wallet/src/de/schildbach/wallet/ui/WalletAddressesFragment.java
+++ b/wallet/src/de/schildbach/wallet/ui/WalletAddressesFragment.java
@@ -197,8 +197,8 @@ public final class WalletAddressesFragment extends FancyListFragment {
                         clipboardManager.setPrimaryClip(ClipData.newPlainText("Bitcoin privKey", privKey));
                         log.info("private key copied to clipboard: {}", privKey);
                     }
-                    final DialogBuilder builder = DialogBuilder.warn(activity, R.string.action_private_key);
-                    builder.setMessage(privKey);
+                    final DialogBuilder builder = DialogBuilder.warn(activity, R.string.dialog_private_key_title);
+                    builder.setMessage(getString(R.string.dialog_private_key_warning) + "\n\n" + privKey);
                     builder.singleDismissButton(new DialogInterface.OnClickListener() {
                         @Override
                         public void onClick(DialogInterface dialogInterface, int i) {


### PR DESCRIPTION
The option requires ActionMode and is located last in the menu.
The private key can then be displayed in a warning Dialog as WIF format.

"your private key your bitcoin, not your private key not your bitcoin"