### PR TITLE
Add badges for F-Droid and Google Play

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,3 @@ This project contains several sub-projects:
 You can build all sub-projects at once using Gradle:
 
 `gradle clean build`
-
-
-
-_Legal note: Google Play and the Google Play logo are trademarks of Google Inc._

--- a/README.md
+++ b/README.md
@@ -1,10 +1,9 @@
 Welcome to _Bitcoin Wallet_, a standalone Bitcoin payment app for your Android device!
 
-<u><a href="https://f-droid.org/app/de.schildbach.wallet">
-    <img src="https://f-droid.org/badge/get-it-on.png"
-         alt="Get it on F-Droid" height="80">
-</a>
-<a href='https://play.google.com/store/apps/details?id=de.schildbach.wallet'><img alt='Get it on Google Play' src='https://play.google.com/intl/en_us/badges/images/generic/en_badge_web_generic.png' height="80"/></a></u>
+You can get the app from the store of your choice:
+<a href="https://f-droid.org/app/de.schildbach.wallet">F-Droid</a> | 
+<a href='https://play.google.com/store/apps/details?id=de.schildbach.wallet'>Google Play</a> | 
+<a href="https://github.com/bitcoin-wallet/bitcoin-wallet/releases">Direct APK download from GitHub</a>
 
 This project contains several sub-projects:
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 Welcome to _Bitcoin Wallet_, a standalone Bitcoin payment app for your Android device!
 
+<u><a href="https://f-droid.org/app/de.schildbach.wallet">
+    <img src="https://f-droid.org/badge/get-it-on.png"
+         alt="Get it on F-Droid" height="80">
+</a>
+<a href='https://play.google.com/store/apps/details?id=de.schildbach.wallet'><img alt='Get it on Google Play' src='https://play.google.com/intl/en_us/badges/images/generic/en_badge_web_generic.png' height="80"/></a></u>
+
 This project contains several sub-projects:
 
  * __wallet__:
@@ -19,3 +25,7 @@ This project contains several sub-projects:
 You can build all sub-projects at once using Gradle:
 
 `gradle clean build`
+
+
+
+_Legal note: Google Play and the Google Play logo are trademarks of Google Inc._

--- a/README.md
+++ b/README.md
@@ -1,9 +1,7 @@
 Welcome to _Bitcoin Wallet_, a standalone Bitcoin payment app for your Android device!
 
 You can get the app from the store of your choice:
-<a href="https://f-droid.org/app/de.schildbach.wallet">F-Droid</a> | 
-<a href='https://play.google.com/store/apps/details?id=de.schildbach.wallet'>Google Play</a> | 
-<a href="https://github.com/bitcoin-wallet/bitcoin-wallet/releases">Direct APK download from GitHub</a>
+<a href="https://f-droid.org/app/de.schildbach.wallet">F-Droid</a> | <a href='https://play.google.com/store/apps/details?id=de.schildbach.wallet'>Google Play</a> | <a href="https://github.com/bitcoin-wallet/bitcoin-wallet/releases">Direct APK download from GitHub</a>
 
 This project contains several sub-projects:
 


### PR DESCRIPTION
I added F-Droid and Play store badges to the README.md as requested in [#409](https://github.com/bitcoin-wallet/bitcoin-wallet/issues/409).