### PR TITLE
Add Java install instructions to README.recover.md

### DIFF
--- a/wallet/README.recover.md
+++ b/wallet/README.recover.md
@@ -37,6 +37,12 @@ On your PC, install the following Ubuntu packages:
 
     sudo apt install android-tools-adb openssl git maven
 
+Install Java if you do not already have it:
+
+    sudo add-apt-repository ppa:webupd8team/java -y
+    sudo apt update
+    sudo apt install oracle-java8-installer oracle-java8-set-default
+
 On your Android device, go to Settings > Developer options and enable "USB debugging". On most
 recent devices you need to go to Settings > About first and tap on "Build number" multiple times
 until you see the "You are now a developer" message.


### PR DESCRIPTION
I needed to do this.

People not familiar with Java may be thrown by the compile time errors that Maven throws when it's not installed.