### PR TITLE
Document how to dump private keys

### DIFF
--- a/wallet/README.recover.md
+++ b/wallet/README.recover.md
@@ -121,7 +121,7 @@ succeeds, it will print the transaction hash of the created transaction. You can
 a block explorer to watch, or just open the destination wallet and watch from there. If your coins
 are confirmed, you're done and you can skip the next paragraph to EPILOGUE.
 
-You can also get a list of the private keys, which would be useful if you want to sweep them into a wallet (for example a Bitcoin Cash wallet). If your wallet had a spending PIN set you need to decrypt it first, otherwise the private keys won't appear:
+You can also get a list of the private keys, which would be useful if you want to sweep them into a wallet (for example a Bitcoin Cash wallet). If your wallet had a spending PIN set you need to decrypt it first, otherwise the private keys won't appear. Note that when you decrypt the wallet *the private keys can be accessed (and your Bitcoins stolen) by anyone with access to the system*, including viruses, trojans, malware or other users. Unless you fully trust the security of the computer consider running it in an offline system with no network connectivity.
 
     ./wallet-tool decrypt --wallet=/tmp/bitcoin-wallet-decrypted-backup --password=<spending-PIN>
 
@@ -129,7 +129,7 @@ Then to get the private keys use `dump --dump-privkeys`:
 
     ./wallet-tool dump --wallet=/tmp/bitcoin-wallet-decrypted-backup --dump-privkeys
 
-Look for `priv WIF=<...>`, where `<...>` will be your private keys.
+Look for `priv WIF=<...>`, where `<...>` will be your private keys. Be careful where you put them, as anybody getting access to them will be able to steal your coins. Consider securely deleting the decrypted wallet once you get your private keys (e.g. with the `shred` command).
 
 ## RECOVERING FROM BASE58 KEY FORMAT
 

--- a/wallet/README.recover.md
+++ b/wallet/README.recover.md
@@ -121,6 +121,15 @@ succeeds, it will print the transaction hash of the created transaction. You can
 a block explorer to watch, or just open the destination wallet and watch from there. If your coins
 are confirmed, you're done and you can skip the next paragraph to EPILOGUE.
 
+You can also get a list of the private keys, which would be useful if you want to sweep them into a wallet (for example a Bitcoin Cash wallet). If your wallet had a spending PIN set you need to decrypt it first, otherwise the private keys won't appear:
+
+    ./wallet-tool decrypt --wallet=/tmp/bitcoin-wallet-decrypted-backup --password=<spending-PIN>
+
+Then to get the private keys use `dump --dump-privkeys`:
+
+    ./wallet-tool dump --wallet=/tmp/bitcoin-wallet-decrypted-backup --dump-privkeys
+
+Look for `priv WIF=<...>`, where `<...>` will be your private keys.
 
 ## RECOVERING FROM BASE58 KEY FORMAT
 


### PR DESCRIPTION
Dumping the private keys is especially useful to sweep the coins into a Bitcoin Cash wallet (and potentially for other future forks).

Kudos go to https://recoverbch.azurewebsites.net/, it's where I found out the crucial step that was missing, `wallet-tool decrypt`, otherwise the private keys wouldn't show when dumping the wallet.