### PR TITLE
Git-ignore Gradle wrapper files.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,7 @@
 .gradle/
+gradlew
+gradlew.bat
+gradle/wrapper
 build/
 local.properties
 .classpath


### PR DESCRIPTION
Android Studio urges you to use Gradle wrapper, and puts these files into the project if you do.

Let's ignore them. Everyone can set up Gradle wrapper with two clicks if wanted.