### PR TITLE
Passwords should be invisible to the accessibility services

### DIFF
--- a/wallet/res/layout/backup_wallet_dialog.xml
+++ b/wallet/res/layout/backup_wallet_dialog.xml
@@ -34,6 +34,7 @@
                 android:layout_weight="3"
                 android:hint="@string/import_export_keys_dialog_password"
                 android:inputType="textPassword"
+                android:importantForAccessibility="no"
                 android:singleLine="true" />
 
             <TextView
@@ -59,6 +60,7 @@
                 android:layout_weight="3"
                 android:hint="@string/backup_wallet_dialog_password_again"
                 android:inputType="textPassword"
+                android:importantForAccessibility="no"
                 android:singleLine="true" />
 
             <TextView

--- a/wallet/res/layout/encrypt_keys_dialog.xml
+++ b/wallet/res/layout/encrypt_keys_dialog.xml
@@ -35,6 +35,7 @@
                 android:hint="@string/encrypt_keys_dialog_password_old"
                 android:imeOptions="flagNoExtractUi"
                 android:inputType="numberPassword"
+                android:importantForAccessibility="no"
                 android:singleLine="true" />
 
             <TextView
@@ -64,6 +65,7 @@
                 android:hint="@string/private_key_password"
                 android:imeOptions="flagNoExtractUi"
                 android:inputType="numberPassword"
+                android:importantForAccessibility="no"
                 android:singleLine="true" />
 
             <TextView

--- a/wallet/res/layout/maintenance_dialog.xml
+++ b/wallet/res/layout/maintenance_dialog.xml
@@ -37,6 +37,7 @@
                 android:hint="@string/private_key_password"
                 android:imeOptions="flagNoExtractUi"
                 android:inputType="numberPassword"
+                android:importantForAccessibility="no"
                 android:singleLine="true" />
 
             <TextView

--- a/wallet/res/layout/raise_fee_dialog.xml
+++ b/wallet/res/layout/raise_fee_dialog.xml
@@ -37,6 +37,7 @@
                 android:hint="@string/private_key_password"
                 android:imeOptions="flagNoExtractUi"
                 android:inputType="numberPassword"
+                android:importantForAccessibility="no"
                 android:singleLine="true" />
 
             <TextView

--- a/wallet/res/layout/restore_wallet_dialog.xml
+++ b/wallet/res/layout/restore_wallet_dialog.xml
@@ -35,6 +35,7 @@
             android:layout_marginTop="@dimen/list_entry_padding_vertical"
             android:hint="@string/import_export_keys_dialog_password"
             android:inputType="textPassword"
+            android:importantForAccessibility="no"
             android:singleLine="true" />
 
         <CheckBox

--- a/wallet/res/layout/restore_wallet_from_external_dialog.xml
+++ b/wallet/res/layout/restore_wallet_from_external_dialog.xml
@@ -19,6 +19,7 @@
             android:layout_marginTop="@dimen/list_entry_padding_vertical"
             android:hint="@string/import_export_keys_dialog_password"
             android:inputType="textPassword"
+            android:importantForAccessibility="no"
             android:singleLine="true" />
 
         <CheckBox

--- a/wallet/res/layout/send_coins_fragment.xml
+++ b/wallet/res/layout/send_coins_fragment.xml
@@ -169,6 +169,7 @@
                 android:hint="@string/private_key_password"
                 android:imeOptions="flagNoExtractUi"
                 android:inputType="numberPassword"
+                android:importantForAccessibility="no"
                 android:singleLine="true" />
 
             <TextView

--- a/wallet/res/layout/sweep_wallet_fragment.xml
+++ b/wallet/res/layout/sweep_wallet_fragment.xml
@@ -51,6 +51,7 @@
                 android:layout_weight="1"
                 android:hint="@string/sweep_wallet_fragment_password"
                 android:inputType="textPassword"
+                android:importantForAccessibility="no"
                 android:singleLine="true" />
 
             <TextView


### PR DESCRIPTION
Due to recent attacks, malicious apps that are using the accessibility service can capture all user inputs. In this case, the passwords should be ignored for the accessibility service, so such attacks cannot happen. This is done by our research project in CISPA, Saarland University, Germany.