### PR TITLE
Change the ripple effect on action buttons

### DIFF
--- a/wallet/res/values/styles.xml
+++ b/wallet/res/values/styles.xml
@@ -59,6 +59,7 @@
         <item name="android:minHeight">?android:attr/actionBarSize</item>
         <item name="android:minWidth">48dp</item>
         <item name="android:drawablePadding">4dp</item>
+        <item name="android:background">?android:attr/selectableItemBackground</item>
     </style>
 
     <style name="My.Widget.ActionButton.Overflow" parent="@android:style/Widget.Material.ActionButton.Overflow">


### PR DESCRIPTION
- The actual version of the app uses the action bar menu item ripple effect on action buttons as you can see here:

![before](https://user-images.githubusercontent.com/1225438/55181359-48b95700-516a-11e9-8c0e-72d97117895a.gif)

- This PR just changes the ripple effect to `selectableItemBackground` as you can see here:

![after](https://user-images.githubusercontent.com/1225438/55181534-9b930e80-516a-11e9-94f0-dd8d0c56c079.gif)

If you think it is better visual feedback as I think please feel free to accept this PR.

Best regards.


