### PR TITLE
Add BTC.com as an explorer for mainnet

### DIFF
--- a/wallet/res/values/values.xml
+++ b/wallet/res/values/values.xml
@@ -26,6 +26,7 @@
         <item>https://live.blockcypher.com/btc-testnet/</item>
     </string-array>
     <string-array name="preferences_block_explorer_labels">
+        <item>btc.com</item>
         <item>blockchain.info</item>
         <item>live.blockcypher.com</item>
     </string-array>


### PR DESCRIPTION
I don't think they serve their explorer site for bitcoin testnet but they are very popular.