### PR TITLE
Add satoshi denomination in wallet

### DIFF
--- a/wallet/res/values/strings.xml
+++ b/wallet/res/values/strings.xml
@@ -256,6 +256,7 @@
     <string name="preferences_precision_labels_4">BTC, 4 decimal places</string>
     <string name="preferences_precision_labels_2_3">mBTC, 2 decimal places</string>
     <string name="preferences_precision_labels_0_6">µBTC, no decimal places</string>
+    <string name="preferences_precision_labels_0_8">sat, no decimal places</string>
     <string name="preferences_own_name_title">Own name</string>
     <string name="preferences_own_name_summary">Name of yourself, to be added to payment requests. Try to keep it short.</string>
     <string name="preferences_send_coins_autoclose_title">Auto-close send coins dialog</string>

--- a/wallet/res/values/values.xml
+++ b/wallet/res/values/values.xml
@@ -13,6 +13,7 @@
         <item>4</item>
         <item>2/3</item>
         <item>0/6</item>
+        <item>0/8</item>
     </string-array>
     <string-array name="preferences_precision_labels">
         <item>@string/preferences_precision_labels_8</item>
@@ -20,6 +21,7 @@
         <item>@string/preferences_precision_labels_4</item>
         <item>@string/preferences_precision_labels_2_3</item>
         <item>@string/preferences_precision_labels_0_6</item>
+        <item>@string/preferences_precision_labels_0_8</item>
     </string-array>
     <string-array name="preferences_block_explorer_values">
         <item>https://www.blockchain.com/btctest/</item>


### PR DESCRIPTION
Not sure if the attached commit already is enough, but having a Satoshi display/denomination would be great!

There is no discussion on what a Satoshi is.

Especially for Lighting users, Satoshi display could be useful.

Thanks for your consideration.