### PR TITLE
gradle build update for 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,10 +1,11 @@
 buildscript {
     repositories {
+        google()
         jcenter()
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.3'
+        classpath 'com.android.tools.build:gradle:3.5.0'
         classpath('fr.avianey.androidsvgdrawable:gradle-plugin:3.0.2') {
             exclude group: 'xerces'
         }
@@ -13,6 +14,7 @@ buildscript {
 
 allprojects {
     repositories {
+        google()
         jcenter()
         maven {
             url 'https://maven.google.com'

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,3 @@
 org.gradle.jvmargs=-Xmx2048M
+android.useAndroidX=true
+android.enableJetifier=true

--- a/wallet/build.gradle
+++ b/wallet/build.gradle
@@ -30,6 +30,7 @@ dependencies {
     compile 'com.squareup.moshi:moshi:1.6.0'
     compile 'org.slf4j:slf4j-api:1.7.28'
     compile 'com.github.tony19:logback-android:2.0.0'
+    compile 'com.android.support:appcompat-v7:23.2.0'
     testCompile 'junit:junit:4.12'
 }
 
@@ -40,6 +41,10 @@ ext {
 android {
     compileSdkVersion 'android-28'
     buildToolsVersion '28.0.3'
+
+    defaultConfig {
+      vectorDrawables.useSupportLibrary = true
+    }
 
     lintOptions {
         abortOnError false


### PR DESCRIPTION
I need this changes to get 'BUILD SUCCESSFUL' under Ubuntu 18.04.3 LTS with Gradle 5.6.2 and openjdk version 1.8.0_222 (openjdk-8)

Notes 
- I was not able to build with openjdk 11 (available in Ubuntu). Downgraded to openjdk 8 (available in Ubuntu)
- I was not able to build with gradle 4.4.1 (available in Ubuntu). Upgraded to Gradle 5.6.2 (manual install from gradle.org)