### PR TITLE
Update decrypting command line to explicitly specify digest

### DIFF
--- a/wallet/src/de/schildbach/wallet/util/Crypto.java
+++ b/wallet/src/de/schildbach/wallet/util/Crypto.java
@@ -42,7 +42,7 @@ import java.util.Arrays;
  * This class encrypts and decrypts a string in a manner that is compatible with OpenSSL.
  * 
  * If you encrypt a string with this class you can decrypt it with the OpenSSL command: openssl enc -d
- * -aes-256-cbc -a -in cipher.txt -out plain.txt -pass pass:aTestPassword
+ * -aes-256-cbc -a -in cipher.txt -out plain.txt -md md5 -pass pass:aTestPassword
  * 
  * where: cipher.txt = file containing the cipher text plain.txt - where you want the plaintext to be saved
  * 


### PR DESCRIPTION
The decrypting command line specified in comment did not work for me (OpenSSL 1.1.1f, Ubuntu 20.04.3). After a bit of googling, I've found this answer: https://stackoverflow.com/a/43847627/3216312 that suggested to explicitly add `-md md5`, and this worked.