### PR TITLE
settings.gradle, README.md: declare a maximum Gradle version

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This project contains several sub-projects:
 
 ### PREREQUISITES FOR BUILDING
 
-You'll need git, a Java 11 SDK and Gradle 4.4 (or later) for this. We'll assume Ubuntu 22.04 LTS (Jammy Jellyfish)
+You'll need git, a Java 11 SDK and Gradle between 4.4 and 6.9.x for this. We'll assume Ubuntu 22.04 LTS (Jammy Jellyfish)
 for the package installs, which comes with OpenJDK 11 and Gradle 4.4.1 out of the box.
 
     # first time only

--- a/settings.gradle
+++ b/settings.gradle
@@ -2,10 +2,11 @@ import org.gradle.util.GradleVersion
 import org.gradle.api.GradleScriptException
 
 // required Gradle version
-def minGradleVersion = GradleVersion.version("4.4")
+def minGradleVersion = GradleVersion.version("4.4") // including
+def maxGradleVersion = GradleVersion.version("7.0") // excluding
 
-if (GradleVersion.current() < minGradleVersion)
-    throw new GradleScriptException("build requires Gradle ${minGradleVersion.version} or later", null)
+if (GradleVersion.current() < minGradleVersion || GradleVersion.current() >= maxGradleVersion)
+    throw new GradleScriptException("build requires Gradle between ${minGradleVersion.version} (including) and ${maxGradleVersion.version} (excluding)", null)
 
 gradle.startParameter.excludedTaskNames << "lint"
 gradle.startParameter.excludedTaskNames << "lintVitalDevRelease"


### PR DESCRIPTION
I chose to declare an open upper bound (rather than closed) so that future maintenance releases in the 6.9.x series would automatically be included in the supported versions.