### PR TITLE
Remove the spending PIN encryption before backup

### DIFF
--- a/wallet/res/layout/backup_wallet_dialog.xml
+++ b/wallet/res/layout/backup_wallet_dialog.xml
@@ -91,5 +91,36 @@
             android:text="@string/backup_wallet_dialog_warning_encrypted"
             android:textColor="@color/fg_less_significant"
             android:textSize="@dimen/font_size_small" />
+
+        <LinearLayout
+            android:id="@+id/backup_wallet_dialog_spending_pin_group"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="@dimen/list_entry_padding_vertical"
+            android:divider="@drawable/divider_field"
+            android:orientation="horizontal"
+            android:showDividers="middle"
+            android:visibility="gone">
+
+            <EditText
+                android:id="@+id/backup_wallet_dialog_spending_pin"
+                android:layout_width="0px"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:hint="@string/private_key_password"
+                android:imeOptions="flagNoExtractUi"
+                android:inputType="numberPassword"
+                android:singleLine="true" />
+
+            <TextView
+                android:id="@+id/backup_wallet_dialog_bad_spending_pin"
+                android:layout_width="0px"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:text="@string/private_key_bad_password"
+                android:textColor="@color/fg_error"
+                android:textStyle="bold"
+                android:visibility="invisible" />
+        </LinearLayout>
     </LinearLayout>
 </ScrollView>

--- a/wallet/res/values/strings.xml
+++ b/wallet/res/values/strings.xml
@@ -205,7 +205,8 @@
     <string name="import_keys_dialog_failure">Wallet could not be restored:\n\n%s\n\nBad password?</string>
     <string name="export_keys_dialog_title">Back up wallet</string>
     <string name="backup_wallet_dialog_message">Your backup will be encrypted with the chosen password and written to external storage.</string>
-    <string name="backup_wallet_dialog_warning_encrypted">Your wallet is protected by a spending PIN. Make sure you remember the PIN in addition to the backup password!</string>
+    <string name="backup_wallet_dialog_warning_encrypted">Your spending PIN protection won\'t be present in the backup. Make sure you set the PIN again if you restore the wallet!</string>
+    <string name="backup_wallet_dialog_state_verifying">Verifying...</string>
     <string name="export_keys_dialog_button_export">Back up</string>
     <string name="export_keys_dialog_success"><![CDATA[<p>Your wallet has been backed up to <tt>%s</tt></p><p><b>If the only place your backup exists is on your device, you run the risk of losing both at the same time!</b></p><p>In any case, make sure you remember your backup password.</p>]]></string>
     <string name="export_keys_dialog_failure">Your wallet could not be backed up:\n%s</string>

--- a/wallet/src/de/schildbach/wallet/ui/backup/BackupWalletViewModel.java
+++ b/wallet/src/de/schildbach/wallet/ui/backup/BackupWalletViewModel.java
@@ -19,6 +19,7 @@ package de.schildbach.wallet.ui.backup;
 
 import androidx.lifecycle.MutableLiveData;
 import androidx.lifecycle.ViewModel;
+import org.bitcoinj.wallet.Wallet;
 
 /**
  * @author Andreas Schildbach
@@ -34,4 +35,5 @@ public class BackupWalletViewModel extends ViewModel {
 
     public final MutableLiveData<String> password = new MutableLiveData<>();
     public final MutableLiveData<String> spendingPIN = new MutableLiveData<>();
+    public final MutableLiveData<Wallet> walletToBackup = new MutableLiveData<>();
 }

--- a/wallet/src/de/schildbach/wallet/ui/backup/BackupWalletViewModel.java
+++ b/wallet/src/de/schildbach/wallet/ui/backup/BackupWalletViewModel.java
@@ -24,5 +24,14 @@ import androidx.lifecycle.ViewModel;
  * @author Andreas Schildbach
  */
 public class BackupWalletViewModel extends ViewModel {
+
+    public enum State {
+        INPUT, CRYPTING, BADPIN, EXPORTING
+    }
+
+
+    public final MutableLiveData<State> state = new MutableLiveData<>(State.INPUT);
+
     public final MutableLiveData<String> password = new MutableLiveData<>();
+    public final MutableLiveData<String> spendingPIN = new MutableLiveData<>();
 }


### PR DESCRIPTION
This pull request modifies the backup process for the Bitcoin Wallet by introducing a prompt for the spending PIN if one is set. The backup file will now be encrypted only by the key derived from the backup password, avoiding double encryption. Additionally, users now only need to remember the backup password instead of both the password and spending PIN when importing and using the wallet later.

<img src="https://github.com/bitcoin-wallet/bitcoin-wallet/assets/74351228/cd436a88-e803-47ae-96f5-60c52b29b938" width="300" height="592">

This change addresses [feedback](https://github.com/bitcoin-wallet/bitcoin-wallet/pull/1121#issuecomment-2094793140) from another [open pull request](https://github.com/bitcoin-wallet/bitcoin-wallet/pull/1121). 

While the changes have been tested on Android 8.0 (API level 26) and Android 14 (API level 34), a thorough review is necessary due to the criticality of the encryption state.

Authors: [Sebastian Nicol ](https://github.com/iSavicx)and [Oliver Aemmer](https://github.com/oliveraemmer)